### PR TITLE
dependent: :destroy relations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   # Awesome print
   gem 'awesome_print'
 
+  # Guard for automation goodies
   gem 'guard'
   gem 'guard-process'
 
@@ -50,5 +51,8 @@ group :development, :test do
   gem 'capistrano-rails', '~> 1.1'
   gem 'capistrano-rvm'
   gem 'capistrano-passenger'
+
+  # Pry-rails for better console
+  gem 'pry-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -250,6 +252,7 @@ DEPENDENCIES
   jquery-rails
   passenger
   pg
+  pry-rails
   rails (= 4.2.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ActiveRecord::Base
-  has_many :taggings
+  has_many :taggings, dependent: :destroy
   has_many :tasks, through: :taggings
   has_many :time_entries, through: :tasks
   belongs_to :user

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ActiveRecord::Base
-  has_many :taggings
+  has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
-  has_many :time_entries
+  has_many :time_entries, dependent: :destroy
   belongs_to :user
 
   validates_presence_of :user_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :time_entries
-  has_many :tags
-  has_many :tasks
+  has_many :time_entries, dependent: :destroy
+  has_many :tags, dependent: :destroy
+  has_many :tasks, dependent: :destroy
 end

--- a/db/migrate/20160304002440_remove_orphans.rb
+++ b/db/migrate/20160304002440_remove_orphans.rb
@@ -1,0 +1,10 @@
+class RemoveOrphans < ActiveRecord::Migration
+  def change
+    Tagging.all.each do |tagging|
+      tagging.destroy if tagging.tag.nil? || tagging.task.nil?
+    end
+    TimeEntry.all.each { |te| te.destroy if te.task.nil? || te.user.nil? }
+    Task.all.each { |task| task.destroy if task.user.nil? }
+    Tag.all.each { |tag| tag.destroy if tag.user.nil? }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160301181352) do
+ActiveRecord::Schema.define(version: 20160304002440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,7 +1,23 @@
 require 'test_helper'
 
 class TagTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @tag = tags(:one)
+    @task = tasks(:one)
+  end
+
+  test "does not orphan taggings" do
+    before_taggings = Tagging.count
+
+    @tag.save!
+    @tag.tasks << @task
+
+    # Assert tagging was created
+    assert_equal(Tagging.count, before_taggings + 1)
+
+    @tag.destroy
+
+    # Assert tagging was destroyed
+    assert_equal(Tagging.count, before_taggings)
+  end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,7 +1,38 @@
 require 'test_helper'
 
 class TaskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @task = tasks(:one)
+    @tag = tags(:one)
+    @time_entry = time_entries(:one)
+  end
+
+  test "does not orphan taggings" do
+    before_taggings = Tagging.count
+
+    @task.save!
+    @task.tags << @tag
+
+    # Assert tagging was created
+    assert_equal(Tagging.count, before_taggings + 1)
+
+    @task.destroy
+
+    # Assert tagging was destroyed
+    assert_equal(Tagging.count, before_taggings)
+  end
+
+  test "does not orphan time entries" do
+    before_count = TimeEntry.count
+
+    @task.save!
+
+    # Associate this time_entry to the task
+    @time_entry.update(task_id: @task.id)
+
+    @task.destroy
+
+    # Assert the time entry was destroyed with the task
+    assert_equal(TimeEntry.count, before_count - 1)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,35 +12,38 @@ class UserTest < ActiveSupport::TestCase
     @user.save!
     @tag.save!
 
+    before = Tag.count
+
     @tag.update(user: @user)
     @user.destroy
 
-    # Assert that the tag was destroyed
-    assert(@tag.destroyed?, "Tag not destroyed")
+    # Assert that one or more tags was destroyed
+    assert(before > Tag.count, "No tags destroyed")
   end
 
   test "does not orphan tasks" do
     @user.save!
     @task.save!
 
+    before = Task.count
+
     @task.update(user: @user)
     @user.destroy
 
     # Assert that the task was destroyed
-    assert(@task.destroyed?, "Task not destroyed")
+    assert(before > Task.count, "No tasks destroyed")
   end
 
-  # test "does not orphan time_entries" do
-  #   @user.save!
-  #   @time_entry.save!
+  test "does not orphan time_entries" do
+    @user.save!
+    @time_entry.save!
 
-  #   before_time_entries = time_entry.count
+    before = TimeEntry.count
 
-  #   @time_entry.update!(user: @user)
+    @time_entry.update!(user: @user)
+    @user.destroy
 
-  #   @user.destroy
-
-  #   # Assert that the time_entry was destroyed
-  #   assert_equal(time_entry.count, before_time_entries - 1)
-  # end
+    # Assert that the time_entry was destroyed
+    assert(before > TimeEntry.count, "Time Entry not destroyed")
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,46 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
+  setup do
+    @user = users(:one)
+    @tag = tags(:one)
+    @task = tasks(:one)
+    @time_entry = time_entries(:one)
+  end
+
+  test "does not orphan tags" do
+    @user.save!
+    @tag.save!
+
+    @tag.update(user: @user)
+    @user.destroy
+
+    # Assert that the tag was destroyed
+    assert(@tag.destroyed?, "Tag not destroyed")
+  end
+
+  test "does not orphan tasks" do
+    @user.save!
+    @task.save!
+
+    @task.update(user: @user)
+    @user.destroy
+
+    # Assert that the task was destroyed
+    assert(@task.destroyed?, "Task not destroyed")
+  end
+
+  # test "does not orphan time_entries" do
+  #   @user.save!
+  #   @time_entry.save!
+
+  #   before_time_entries = time_entry.count
+
+  #   @time_entry.update!(user: @user)
+
+  #   @user.destroy
+
+  #   # Assert that the time_entry was destroyed
+  #   assert_equal(time_entry.count, before_time_entries - 1)
   # end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,10 +3,10 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  include Devise::TestHelpers
-
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
+end
 
-  # Add more helper methods to be used by all tests here...
+class ActionController::TestCase
+  include Devise::TestHelpers
 end


### PR DESCRIPTION
Now `Tagging`s are destroyed alongside their tags or tasks. `TimeEntry`s are destroyed alongside their tasks.