### PR TITLE
Removed user_id from time_entry

### DIFF
--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -1,8 +1,8 @@
 require 'csv'
 
 class TimeEntry < ActiveRecord::Base
-  belongs_to :user
   belongs_to :task
+  has_one :user, through: :task
   has_many :tags, through: :task
 
   validates_presence_of :task_id

--- a/db/migrate/20160226170537_remove_user_id_from_time_entries.rb
+++ b/db/migrate/20160226170537_remove_user_id_from_time_entries.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromTimeEntries < ActiveRecord::Migration
+  def change
+    remove_column :time_entries, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160224131033) do
+ActiveRecord::Schema.define(version: 20160226170537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,6 @@ ActiveRecord::Schema.define(version: 20160224131033) do
   end
 
   create_table "time_entries", force: :cascade do |t|
-    t.integer  "user_id"
     t.integer  "task_id"
     t.integer  "duration"
     t.datetime "start_time"


### PR DESCRIPTION
The idea here is that time entries should derive their user from their tasks.
The idea of a time entry belonging to a user whom the task does not belong to is
void unless tasks can be shared, but not owned, by other users.