### PR TITLE
Fixed wording in TE form

### DIFF
--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -32,6 +32,6 @@
     <%= f.number_field :duration, class: "form-control" %>
   </div>
   <div class="actions col-xs-12">
-    <%= f.submit "Create entry", class: "btn btn-primary" %>
+    <%= f.submit nil, class: "btn btn-primary" %>
   </div>
 <% end %>


### PR DESCRIPTION
Until now, the form has always said "Create", even when you are editing. This rectifies that.