### PR TITLE
Fixed due date bug on update

### DIFF
--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -3,30 +3,6 @@
 // You can use CoffeeScript in this file: http://coffeescript.org/
 
 $(function() {
-    var hideOrShowDueDate = function() {
-        const checked = $("#task_due").is(':checked');
-
-        if (checked) {
-            const date = new Date();
-
-            $("#task_due_date_1i").val(String(1900 + date.getYear()));
-            $("#task_due_date_2i").val(String(1 + date.getMonth()));
-            $("#task_due_date_3i").val(String(date.getDate()));
-
-            $("#task_due_date_1i").show();
-            $("#task_due_date_2i").show();
-            $("#task_due_date_3i").show();
-        } else {
-            $("#task_due_date_1i").val(null);
-            $("#task_due_date_2i").val(null);
-            $("#task_due_date_3i").val(null);
-
-            $("#task_due_date_1i").hide();
-            $("#task_due_date_2i").hide();
-            $("#task_due_date_3i").hide();
-        }
-    }
-
     var loadSelect2 = function() {
         $("#task_tag_ids").select2();
     }
@@ -61,10 +37,9 @@ $(function() {
     }
 
     $(document).on("page:change", function() {
-        $("#task_due").change(hideOrShowDueDate);
         $("#archive-toggle").click(toggleArchived);
+	$("#task_datetimepicker").datetimepicker({ format: "L" });
 	setupCompleteHandlers();
-        hideOrShowDueDate();
         loadSelect2();
     });
 });

--- a/app/assets/javascripts/time_entries.js
+++ b/app/assets/javascripts/time_entries.js
@@ -19,7 +19,7 @@ $(function() {
 
     $(document).on("page:change", function() {
 	hideOrShowFields();
-	$('#datetimepicker1').datetimepicker();
+	$('#te_datetimepicker').datetimepicker();
 	$('input[name="time_entry[running]"]').change(hideOrShowFields);
     })
 });

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -72,6 +72,9 @@ class TasksController < ApplicationController
                                                 :user_id, :due_date,
                                                 tag_ids: [])
       new_params[:user_id] = current_user.id unless current_user.admin?
+      unless new_params[:due_date].blank?
+        new_params[:due_date] = Date.american_date(new_params[:due_date])
+      end
       new_params
     end
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -30,15 +30,19 @@
     </div>
     <div class="form-group col-md-4">
       <%= f.label :due_date %><br>
-      <input type="checkbox" id="task_due" <%= "checked=checked" unless @task.due_date.nil? %> />
-      <%= f.date_select :due_date, class: "form-control", visible: @task.due_date.nil? %>
+      <div class='input-group date' id='task_datetimepicker'>
+	<%= f.text_field :due_date, value: @task.due_date.try(:american_date), class: "form-control" %>
+	<span class="input-group-addon">
+	  <span class="glyphicon glyphicon-calendar"></span>
+	</span>
+      </div>
     </div>
     <% if current_user.admin? %>
       <div class="form-group col-md-4">
         <%= f.label :user_id, "User" %><br>
         <%= f.collection_select :user_id, @users, :id, :username, {}, class: "form-control" %>
       </div>
-  <% end %>
+    <% end %>
   </div>
   <div class="actions">
     <%= f.submit(nil, class: "btn btn-primary") %>

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -29,7 +29,7 @@
   </div>
   <div class="form-group col-md-4">
     <%= f.label :start_time %><br>
-    <div class='input-group date' id='datetimepicker1'>
+    <div class='input-group date' id='te_datetimepicker'>
       <%= f.text_field :start_time, value: @time_entry.start_time.american_date, class: "form-control" %>
       <span class="input-group-addon">
 	<span class="glyphicon glyphicon-calendar"></span>

--- a/config/initializers/monkey_patching.rb
+++ b/config/initializers/monkey_patching.rb
@@ -1,2 +1,5 @@
 Time.extend CoreExtensions::Time::CustomFormats::ClassMethods
 Time.include CoreExtensions::Time::CustomFormats::InstanceMethods
+
+Date.extend CoreExtensions::Date::CustomFormats::ClassMethods
+Date.include CoreExtensions::Date::CustomFormats::InstanceMethods

--- a/lib/core_extensions/date/custom_formats.rb
+++ b/lib/core_extensions/date/custom_formats.rb
@@ -1,17 +1,17 @@
 module CoreExtensions
-  module Time
+  module Date
     module CustomFormats
-      AMERICAN_DATE_TIME_FORMAT = "%m/%d/%Y %H:%M %p"
+      AMERICAN_DATE_FORMAT = "%m/%d/%Y"
 
       module InstanceMethods
         def american_date
-          strftime(AMERICAN_DATE_TIME_FORMAT)
+          strftime(AMERICAN_DATE_FORMAT)
         end
       end
 
       module ClassMethods
         def american_date str
-          strptime(str, AMERICAN_DATE_TIME_FORMAT)
+          strptime(str, AMERICAN_DATE_FORMAT)
         end
       end
     end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -6,6 +6,14 @@ class TasksControllerTest < ActionController::TestCase
     sign_in @user
 
     @task = tasks(:one)
+
+    @params = {
+      task_name: "Foobar",
+      tags: tags(:one),
+      priority: 1,
+      estimate: 60,
+      due_date: "08/05/2016"
+    }
   end
 
   test "should get index" do
@@ -21,7 +29,7 @@ class TasksControllerTest < ActionController::TestCase
 
   test "should create task" do
     assert_difference('Task.count') do
-      post :create, task: { task_name: @task.task_name }
+      post :create, task: @params
     end
 
     assert_redirected_to tasks_path(assigns(:tasks))
@@ -33,7 +41,7 @@ class TasksControllerTest < ActionController::TestCase
   end
 
   test "should update task" do
-    patch :update, id: @task, task: { task_name: @task.task_name }
+    patch :update, id: @task, task: @params
     assert_redirected_to tasks_path(assigns(:tasks))
   end
 


### PR DESCRIPTION
Since the introduction of due dates, the JavaScript has always set the due date
to be the current day's date, even if you are editing an older task whose due
date is far in the future. This PR makes it so that dates will not be
overridden and uses the pretty date picker pulled in for Time Entry start times.

UPDATED 2016-08-27 to reflect new approach.