### PR TITLE
View other user's tasks bugfix

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,7 +10,7 @@ class TasksController < ApplicationController
     @tasks = @tasks.where(user: current_user) unless current_user.admin?
 
     @active = @tasks.active
-    @archived = @tasks.unscoped.archived.order(archived_at: :desc)
+    @archived = @tasks.archived.reorder(archived_at: :desc)
   end
 
   def new

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,6 +42,13 @@ j3rn_tasks = j3rn_tags.first.tasks.create!([
     priority: 3,
     user_id: j3rn.id,
     archived_at: DateTime.now,
+  },
+  {
+    task_name: 'Homework #2',
+    priority: 5,
+    user_id: j3rn.id,
+    archived_at: DateTime.now - 3.days,
+    due_date: DateTime.now - 3.day
   }
 ])
 
@@ -56,5 +63,18 @@ test_tags = test.tags.create!([
 ])
 
 test_tags.last.tasks.create!([
-  { task_name: 'Testing things', user_id: test.id }
+  {
+    task_name: 'Testing things',
+    user_id: test.id
+  },
+  { task_name: 'Testing some things',
+    user_id: test.id,
+    archived_at: DateTime.now,
+    due_date: Date.today
+  },
+  {
+    task_name: 'Testing other things',
+    user_id: test.id,
+    archived_at: DateTime.now - 1.days
+  }
 ])

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -44,4 +44,11 @@ class TasksControllerTest < ActionController::TestCase
 
     assert_redirected_to tasks_path
   end
+
+  test "should not see others' tasks" do
+    get :index
+
+    assert_equal(@user.tasks.active.count, assigns(:active).count)
+    assert_equal(@user.tasks.archived.count, assigns(:archived).count)
+  end
 end

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -3,7 +3,22 @@
 one:
   user: one
   task_name: Task One
+  priority: 4
+  due_date: <%= Date.today + 1 %>
 
 two:
   user: one
   task_name: Task Two
+  archived_at: <%= DateTime.now - 1.days %>
+
+three:
+  user: two
+  priority: 2
+  task_name: Task Three
+  due_date: <%= Date.today + 1 %>
+
+four:
+  user: two
+  task_name: Task Four
+  archived_at: <%= DateTime.now - 1.days %>
+  due_date: <%= Date.today + 1 %>


### PR DESCRIPTION
The answer was to do `reorder` instead of `unscoped`.

Fixes #22