### PR TITLE
Super minor >= 60 fix

### DIFF
--- a/app/helpers/time_entries_helper.rb
+++ b/app/helpers/time_entries_helper.rb
@@ -1,6 +1,6 @@
 module TimeEntriesHelper
   def duration_display(minutes)
-    if minutes > 60
+    if minutes >= 60
       hours = minutes / 60
       minutes = minutes - (hours * 60)
 
@@ -11,7 +11,7 @@ module TimeEntriesHelper
   end
 
   def long_duration_display(minutes)
-    if minutes > 60
+    if minutes >= 60
       hours = minutes / 60
       minutes = minutes - (hours * 60)
 


### PR DESCRIPTION
For the duration display helper methods, the time would be shown in minutes if
it was exactly 60 minutes, and I would prefer for it to be shown as "1 hour"