### PR TITLE
Confirm deleting Time Entries

### DIFF
--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -60,7 +60,7 @@
             <%= button_to 'Edit', edit_time_entry_path(entry), method: :get, class: "btn btn-default" %>
           </td>
           <td class="col-md-1">
-            <%= button_to 'Delete', entry, method: :delete, class: "btn btn-danger" %>
+            <%= button_to 'Delete', entry, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
Currently, you have to confirm deleting Tasks and Tags, but no such
protection was in place for deleting Time Entries. This bit me a couple
of times, so I'm adding in that protection measure.