### PR TITLE
Dependency update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,14 +18,13 @@ gem 'devise'
 gem 'bootstrap-sass'
 gem 'autoprefixer-rails'
 
-# Use passenger for server
-gem 'passenger'
+group :production do
+  # Use passenger for server
+  gem 'passenger'
 
-# Use Dotenv for env vars
-gem 'dotenv-rails', group: :production
-
-# Use Babel for ES6 support
-gem 'sprockets-es6'
+  # Use Dotenv for env vars
+  gem 'dotenv-rails'
+end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,10 +41,6 @@ GEM
       execjs
       json
     awesome_print (1.6.1)
-    babel-source (5.8.35)
-    babel-transpiler (0.7.0)
-      babel-source (>= 4.0, < 6)
-      execjs (~> 2.0)
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -204,10 +200,6 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-es6 (0.9.0)
-      babel-source (>= 5.8.11)
-      babel-transpiler
-      sprockets (>= 3.0.0)
     sprockets-rails (3.0.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -262,7 +254,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  sprockets-es6
   therubyracer
   turbolinks
   uglifier (>= 1.3.0)


### PR DESCRIPTION
I moved passenger and dotenv into the 'production' group so they won't
be installed in CI. I also removed the babel dependence because it
wasn't used.