### PR TITLE
Overdue task style

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -20,27 +20,59 @@
 }
 
 // For color swatches
+
+// Color Definitions
+$gray: gray;
+$green:  green;
+$yellow: yellow;
+$orange: orange;
+$red:    red;
+
+
 .swatch {
   width: 15px;
+  border-right: 1px solid #ccc;
 }
 
 .priority1 {
+  background: $gray;
+
+  &.overdue {
+    background: lighten($gray, 40%);
+  }
 }
 
 .priority2 {
-  background: green;
+  background: $green;
+
+  &.overdue {
+    background: lighten($green, 70%);
+  }
+
 }
 
 .priority3 {
-  background: yellow;
+  background: $yellow;
+
+  &.overdue {
+    background: lighten($yellow, 40%);
+  }
 }
 
 .priority4 {
-  background: orange;
+  background: $orange;
+
+  &.overdue {
+    background: lighten($orange, 30%);
+  }
 }
 
 .priority5 {
-  background: red;
+  background: $red;
+
+  &.overdue {
+    background: lighten($red, 40%);
+  }
 }
 
 #admin {

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -38,6 +38,6 @@ class Task < ActiveRecord::Base
   end
 
   def overdue?
-    true unless days_left.nil? || days_left >= 0 || archived?
+    !archived? && days_left.present? && days_left < 0
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -36,4 +36,8 @@ class Task < ActiveRecord::Base
   def days_left
     (self.due_date - Date.today).to_i if self.due_date
   end
+
+  def overdue?
+    true unless days_left.nil? || days_left >= 0 || archived?
+  end
 end

--- a/app/views/tasks/_task_table.html.erb
+++ b/app/views/tasks/_task_table.html.erb
@@ -18,7 +18,7 @@
       <% if task.overdue? %>
         <tr class="priority<%= task.priority %> overdue">
       <% else %>
-      <tr>
+        <tr>
       <% end %>
         <td class="swatch priority<%= task.priority %>"></td>
 	<td>

--- a/app/views/tasks/_task_table.html.erb
+++ b/app/views/tasks/_task_table.html.erb
@@ -15,7 +15,11 @@
 
   <tbody>
     <% tasks.each do |task| %>
+      <% if task.overdue? %>
+        <tr class="priority<%= task.priority %> overdue">
+      <% else %>
       <tr>
+      <% end %>
         <td class="swatch priority<%= task.priority %>"></td>
 	<td>
 	  <% if task.archived? %>


### PR DESCRIPTION
Hi @J3RN!  :wave:

I had a few minutes today to participate in Hacktoberfest, and I came across #46 where you mentioned wanting overdue items to visually stand out.

This Pull Request adds some simple line highlighting to overdue rows in the task table.  An overdue item's row receives a lighter version of it's corresponding priority swatch.

I did end up changing the color for priority 1 to gray, but I also refactored the styles a bit to make future color maintenance a bit easier.

If you have some time to play around with this, let me know what you think!  I'm happy to make changes, but feel free to :hammer: around on this branch too! :smiley:

#### Screenshot
![screen shot 2016-10-10 at 2 54 29 pm](https://cloud.githubusercontent.com/assets/3477155/19247903/2b9ea5c8-8efb-11e6-8732-d89f15a8f6e1.png)
