### PR TITLE
Timezone "Time due today" fix

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -44,16 +44,18 @@ class Task < ActiveRecord::Base
   def time_remaining_today
     return 0 unless self.due_date && self.estimate
 
-    entries_before_today = self.time_entries.where("start_time < ?", Date.today)
+    today = Date.today.to_time
+
+    entries_before_today = self.time_entries.where("start_time < ?", today)
     done_before_today = entries_before_today.sum(:duration)
 
     per_day = self.estimate - done_before_today
 
     if self.due_date > Date.today
-      per_day = per_day / (self.due_date - Date.today).to_f
+      per_day = per_day / days_left.to_f
     end
 
-    todays_entries = self.time_entries.where("start_time >= ? AND start_time < ?", Date.today, Date.today + 1)
+    todays_entries = self.time_entries.where("start_time >= ? AND start_time < ?", today, today + 1.days)
     done_today = todays_entries.sum(:duration)
 
     per_day - done_today

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -50,4 +50,10 @@ class TaskTest < ActiveSupport::TestCase
     @task.update(due_date: Date.today - 1.days)
     assert_equal(60, @task.time_remaining_today)
   end
+
+  test "time remaining handles timezones at least sort of" do
+    initial_time_remaining = @task.time_remaining_today
+    @task.time_entries.create!(user: users(:one), duration: 30, start_time: Date.today.to_time + 22.hours)
+    assert_equal(initial_time_remaining - 30, @task.time_remaining_today)
+  end
 end


### PR DESCRIPTION
Long story short, `Date#to_time` evidently works better for database queries. It seems that just using a Date didn't account for timezones, but switching it to a Time did.