### PR TITLE
Redirect to start_time day after successful time_entries#edit

### DIFF
--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -130,7 +130,7 @@ class TimeEntriesController < ApplicationController
       if new_params[:running] == "1"
         new_params = remove_stopped_elements(new_params)
       else
-        new_params[:start_time] = Time.american_date(new_params[:start_time])
+        new_params[:start_time] = Time.zone.local_to_utc(Time.american_date(new_params[:start_time]))
       end
 
       new_params

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -79,7 +79,7 @@ class TimeEntriesController < ApplicationController
 
   def update
     if @time_entry.update(time_entry_params)
-      redirect_to time_entries_path
+      redirect_to_entries_on(@time_entry.start_time.to_date)
     else
       render 'edit'
     end
@@ -138,5 +138,12 @@ class TimeEntriesController < ApplicationController
 
     def remove_stopped_elements(new_params)
       new_params.reject { |key, _| [:duration, :start_time, :result].include? key.to_sym }
+    end
+
+    def redirect_to_entries_on(date)
+      args = {}
+      args[:date] = date unless date == Date.today
+
+      redirect_to time_entries_path(args)
     end
 end

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -79,7 +79,7 @@ class TimeEntriesController < ApplicationController
 
   def update
     if @time_entry.update(time_entry_params)
-      redirect_to_entries_on(@time_entry.start_time.to_date)
+      redirect_to time_entries_path(date: @time_entry.start_time.to_date)
     else
       render 'edit'
     end
@@ -138,12 +138,5 @@ class TimeEntriesController < ApplicationController
 
     def remove_stopped_elements(new_params)
       new_params.reject { |key, _| [:duration, :start_time, :result].include? key.to_sym }
-    end
-
-    def redirect_to_entries_on(date)
-      args = {}
-      args[:date] = date unless date == Date.today
-
-      redirect_to time_entries_path(args)
     end
 end

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -51,7 +51,7 @@ class TimeEntriesController < ApplicationController
     @time_entry.start_time ||= DateTime.now
 
     if @time_entry.save
-      redirect_to time_entries_path
+      redirect_to time_entries_path(date: @time_entry.start_time.to_date)
     else
       render 'new'
     end

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -73,7 +73,7 @@ class TimeEntriesControllerTest < ActionController::TestCase
 
   test "redirects to today's entries after updating an entry for today" do
     patch :update, id: @time_entry, time_entry: { start_time: 1.minute.ago.american_date }
-    assert_redirected_to time_entries_path
+    assert_redirected_to time_entries_path(date: Date.today)
   end
 
   test "redirects to past entries after updating a past time entry" do

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -39,7 +39,7 @@ class TimeEntriesControllerTest < ActionController::TestCase
       post :create, time_entry: @params
     end
 
-    assert_redirected_to time_entries_path(assigns(:time_entries))
+    assert_redirected_to time_entries_path(date: assigns(:time_entry).start_time.to_date)
   end
 
   test "renders new on failed time_entry create" do
@@ -48,6 +48,11 @@ class TimeEntriesControllerTest < ActionController::TestCase
     end
 
     assert_response :success
+  end
+
+  test "redirects to past entries after creating an past entry" do
+    post :create, time_entry: @params.dup.update(start_time: (Time.new - 1.day).american_date)
+    assert_redirected_to time_entries_path(date: 1.day.ago.to_date)
   end
 
   test "should get edit" do

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -51,8 +51,9 @@ class TimeEntriesControllerTest < ActionController::TestCase
   end
 
   test "redirects to past entries after creating an past entry" do
-    post :create, time_entry: @params.dup.update(start_time: (Time.new - 1.day).american_date)
-    assert_redirected_to time_entries_path(date: 1.day.ago.to_date)
+    yesterday = Time.current - 1.day
+    post :create, time_entry: @params.dup.update(start_time: yesterday.american_date)
+    assert_redirected_to time_entries_path(date: yesterday.to_date)
   end
 
   test "should get edit" do
@@ -76,8 +77,9 @@ class TimeEntriesControllerTest < ActionController::TestCase
   end
 
   test "redirects to today's entries after updating an entry for today" do
-    patch :update, id: @time_entry, time_entry: { start_time: 1.minute.ago.american_date }
-    assert_redirected_to time_entries_path(date: Date.today)
+    now = Time.current
+    patch :update, id: @time_entry, time_entry: { start_time: now.american_date }
+    assert_redirected_to time_entries_path(date: now.to_date)
   end
 
   test "redirects to past entries after updating a past time entry" do

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -58,9 +58,9 @@ class TimeEntriesControllerTest < ActionController::TestCase
 
   test "should update time_entry" do
     patch :update, id: @time_entry, time_entry: @params
-    assert_redirected_to time_entries_path(assigns(:time_entries))
     @time_entry.reload
-    assert_equal @params[:note], @time_entry.note
+    assert_equal @params[:duration], @time_entry.duration
+    assert_equal @params[:start_time], @time_entry.start_time.american_date
   end
 
   test "renders edit on failed time_entry update" do
@@ -69,6 +69,16 @@ class TimeEntriesControllerTest < ActionController::TestCase
     assert_response :success
     @time_entry.reload
     assert_equal original_note, @time_entry.note
+  end
+
+  test "redirects to today's entries after updating an entry for today" do
+    patch :update, id: @time_entry, time_entry: { start_time: 1.minute.ago.american_date }
+    assert_redirected_to time_entries_path
+  end
+
+  test "redirects to past entries after updating a past time entry" do
+    patch :update, id: @time_entry, time_entry: { start_time: 2.days.ago.american_date }
+    assert_redirected_to time_entries_path(date: 2.days.ago.to_date)
   end
 
   test "should destroy time_entry" do

--- a/test/controllers/time_entries_controller_test.rb
+++ b/test/controllers/time_entries_controller_test.rb
@@ -7,7 +7,6 @@ class TimeEntriesControllerTest < ActionController::TestCase
 
     @time_entry = time_entries(:one)
     @tag = tags(:one)
-    @start_time = "08/02/2016 10:32 PM"
 
     user2 = users(:two)
     @tag2 = tags(:two)
@@ -16,7 +15,7 @@ class TimeEntriesControllerTest < ActionController::TestCase
     @params = {
       duration: 30,
       note: "note",
-      start_time: "08/28/2016 10:30 AM",
+      start_time: Time.new(2016, 8, 28, 10, 30).american_date,
       task_id: tasks(:one).id,
       user_id: users(:one).id
     }


### PR DESCRIPTION
Fix #56 
After a successful `time_entry` update, redirects you to `time_entires#index` for the `start_date` of the `time_entry`.

The `start_date` field gets hidden on `time_entries#new` (since it's blank) so I left that as-is.