### PR TITLE
`order_todo` uses `due_today` instead of `time_remaining_today`

### DIFF
--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -61,4 +61,25 @@ class TaskTest < ActiveSupport::TestCase
     @task.time_entries.create!(user: users(:one), duration: 75, start_time: Date.today.to_time)
     assert_equal(0, @task.time_remaining_today)
   end
+
+  test 'due today base case' do
+    @task.update!(estimate: 100, due_date: Date.today)
+    assert_equal(@task.due_today, 100)
+  end
+
+  test 'due today with time entry' do
+    @task.update!(estimate: 100, due_date: Date.today)
+    @task.time_entries.create!(user: users(:one), duration: 75, start_time: Date.today.to_time)
+    assert_equal(@task.due_today, 100)
+  end
+
+  test 'due today no due date case' do
+    @task.update!(estimate: 100, due_date: nil)
+    assert_equal(@task.due_today, 0)
+  end
+
+  test 'due today no estimate case' do
+    @task.update!(estimate: nil, due_date: Date.today)
+    assert_equal(@task.due_today, 0)
+  end
 end


### PR DESCRIPTION
What it says on the tin.

Task list at the beginning of the day:
![screen shot 2016-10-18 at 11 33 14 pm](https://cloud.githubusercontent.com/assets/2058614/19751031/3df4b1e2-9bc4-11e6-9469-951922b1c5ef.png)

Task list after having logged some time:
![screen shot 2016-10-18 at 11 33 38 pm](https://cloud.githubusercontent.com/assets/2058614/19751039/496eac76-9bc4-11e6-8084-d9a8d1eacdd9.png)

Notice that Task 123 did not drop below Task 456 despite it now having less time remaining. This new behavior encourages users to work on a task until their daily time for it is completed first, then move on to another.

A consequence of this was that `due_today` had to become a public method, and is now tested as such.