### PR TITLE
Adds test coverage gem SimpleCov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,5 +58,7 @@ group :development, :test do
   # Pry-rails for better console
   gem 'pry-rails'
   gem 'therubyracer'
-end
 
+  # SimpleCov for test coverage
+  gem 'simplecov', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    docile (1.1.5)
     dotenv (2.1.0)
     dotenv-rails (2.1.0)
       dotenv (= 2.1.0)
@@ -199,6 +200,11 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shellany (0.0.1)
+    simplecov (0.12.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     spoon (0.0.4)
       ffi
@@ -261,6 +267,7 @@ DEPENDENCIES
   rails (= 4.2.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  simplecov
   spring
   therubyracer
   turbolinks

--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ This is an application that I wrote long ago, but have since repurposed to play 
   ```
   bundle exec passenger start
   ```
+
+## Testing
+
+- Tests can be run using `rake test`
+- For test coverage, run your tests, open up `coverage/index.html` in your browser

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,8 @@
 ENV['RAILS_ENV'] ||= 'test'
+
+require 'simplecov'
+SimpleCov.start
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 


### PR DESCRIPTION
Fix [#85](https://github.com/J3RN/timesheet/issues/85)

Adds SimpleCov as a test coverage solution. After running tests, coverage report is available under `coverage/index.html` as shown below.


<img width="1413" alt="screen shot 2016-10-27 at 12 54 25 am" src="https://cloud.githubusercontent.com/assets/489860/19753070/c5503744-9be0-11e6-9c2f-c44cce816a14.png">
