### PR TITLE
'Ability to run locally with docker'

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.git*
+.dockerignore
+.*.yml
+*.yml
+*.js
+*.md
+*.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.3.1
+
+RUN apt-get update -qq && apt-get install -y build-essential
+
+# for postgres
+RUN apt-get install -y libpq-dev
+
+ENV APP_HOME /srv/http/timesheet
+RUN mkdir -p $APP_HOME
+WORKDIR $APP_HOME
+
+ADD Gemfile* $APP_HOME/
+RUN bundle install
+
+ADD . $APP_HOME/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ ENV RAILS_ENV development
 RUN mkdir -p $APP_HOME
 WORKDIR $APP_HOME
 
-CMD bundle exec passenger start -p 8000
-
 ADD Gemfile* $APP_HOME/
 RUN bundle install
 
@@ -19,4 +17,4 @@ ADD . $APP_HOME/
 
 COPY docker/database.yml $APP_HOME/config/database.yml
 
-#RUN rake db:setup
+CMD bundle exec passenger start -p 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,17 @@ RUN apt-get update -qq && apt-get install -y build-essential
 RUN apt-get install -y libpq-dev
 
 ENV APP_HOME /srv/http/timesheet
+ENV RAILS_ENV development
 RUN mkdir -p $APP_HOME
 WORKDIR $APP_HOME
+
+CMD bundle exec passenger start -p 8000
 
 ADD Gemfile* $APP_HOME/
 RUN bundle install
 
 ADD . $APP_HOME/
+
+COPY docker/database.yml $APP_HOME/config/database.yml
+
+#RUN rake db:setup

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ This is an application that I wrote long ago, but have since repurposed to play 
 
 ## Docker Deploy
 
-[Install docker](https://docs.docker.com/engine/installation/). If there are additional steps to install docker-compose, take them as well.
+* [Install docker](https://docs.docker.com/engine/installation/)
+* [Install docker-compose](https://docs.docker.com/compose/install/)
 
 Run the following three commands in the project's root directory:
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ This is an application that I wrote long ago, but have since repurposed to play 
 
 - Tests can be run using `rake test`
 - For test coverage, run your tests, open up `coverage/index.html` in your browser
+
+## Docker Deploy
+
+[Install docker](https://docs.docker.com/engine/installation/). If there are additional steps to install docker-compose, take them as well.
+
+Run the following three commands in the project's root directory:
+
+```
+docker-compose build
+docker-compose run web rake db:setup
+docker-compose up
+```
+
+The application will now be accessible on `localhost:8000` with any supported web browser.

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,9 @@ default: &default
   adapter: postgresql
   pool: 5
   timeout: 5000
+  username: postgres
+  password:
+  host: db
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,10 @@ services:
 
   web:
     build: .
-    command: bundle exec passenger start -p 3000
+    command: bundle exec passenger start -p 8000
     environment:
       RAILS_ENV: development
     ports:
-      - "3000:3000"
+      - "8000:8000"
     depends_on:
       - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  db:
+    image: postgres
+
+  web:
+    build: .
+    command: bundle exec passenger start -p 3000
+    environment:
+      RAILS_ENV: development
+    volumes:
+      - ".:/srv/http/timesheet"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     command: bundle exec passenger start -p 3000
     environment:
       RAILS_ENV: development
-    volumes:
-      - ".:/srv/http/timesheet"
     ports:
       - "3000:3000"
     depends_on:

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -2,6 +2,9 @@ default: &default
   adapter: postgresql
   pool: 5
   timeout: 5000
+  username: postgres
+  password:
+  host: db
 
 development:
   <<: *default

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -9,16 +9,3 @@ default: &default
 development:
   <<: *default
   database: timesheet-dev
-
-test:
-  <<: *default
-  database: timesheet_test
-
-staging: &staging
-  <<: *default
-  username: <%= ENV["DB_USERNAME"] %>
-  password: <%= ENV["DB_PASSWORD"] %>
-  database: <%= ENV["DB_NAME"] %>
-
-production:
-  <<: *staging


### PR DESCRIPTION
This setup has two docker containers to maximize scalability. This is because one of the images is the web frontend and the other is the database (postgresql) backend. This would be the logical architecture if one were to deploy this over many datacenters, etc. This setup requires ... setup though. 

```
git clone *repo* && cd *repo*
docker-compose build
docker-compose run web rake db:setup
docker-compose up
```

After the last step, the output from the containers are piped to stdout, and killing the output kills the process. This setup is more geared towards the developer and QA, etc. Also, be careful as this does drop a log file and a tmp directory from passenger into the $PWD - that behavior can be changed if necessary.

There is also another approach to dockerize the image, where it is one image. This is considerably easier on the end users to setup and run, and does not require any setup. However, it is completely transparent when it comes to the nuts and bolts, with the most being able to be specified would be the port that it was bound to on localhost. In essence it would just run. That type of image would also be more appropriate to showcase on a "downloads" page for this app.

Let me know if you want one or the other or both. I'll probably have a second branch for the single version later. I wonder what they use at CMM...

EDIT: What directory would you want to expose to the host filesystem? This is in order to backup user data.